### PR TITLE
Add light/dark theme toggle

### DIFF
--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -8,7 +8,10 @@
 </head>
 <body>
     <main class="main-container">
-        <h1 class="title">Tokenizator Plus</h1>
+        <div class="header-bar">
+            <h1 class="title">Tokenizator Plus</h1>
+            <button id="theme-toggle" class="button theme-toggle">Tema Claro</button>
+        </div>
         <p class="subtitle">Cole o caminho de uma pasta e adicione padrões para ignorar arquivos ou diretórios.</p>
 
         <form id="path-form" class="path-form">

--- a/static/app.js
+++ b/static/app.js
@@ -7,6 +7,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const tokenCountSpan = document.getElementById('token-count');
     const controls = document.getElementById('controls');
     const loadingIndicator = document.getElementById('loading');
+    const themeToggle = document.getElementById('theme-toggle');
     
     // Novos elementos para a feature de ignorar
     const ignoreForm = document.getElementById('ignore-form');
@@ -15,6 +16,22 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Estado da aplicação
     let ignorePatterns = [];
+
+    // --- TEMA CLARO/ESCURO ---
+    const setTheme = (theme) => {
+        document.documentElement.setAttribute('data-theme', theme);
+        localStorage.setItem('theme', theme);
+        themeToggle.textContent = theme === 'dark' ? 'Tema Claro' : 'Tema Escuro';
+    };
+
+    const savedTheme = localStorage.getItem('theme') || 'dark';
+    setTheme(savedTheme);
+
+    themeToggle.addEventListener('click', () => {
+        const current = document.documentElement.getAttribute('data-theme');
+        const next = current === 'dark' ? 'light' : 'dark';
+        setTheme(next);
+    });
 
     // --- LÓGICA PARA GERENCIAR A LISTA DE PADRÕES ---
 

--- a/static/style.css
+++ b/static/style.css
@@ -23,6 +23,18 @@ html {
     color-scheme: dark;
 }
 
+html[data-theme='light'] {
+    color-scheme: light;
+    --bg-dark: #f8fafc;     /* bg-gray-50 */
+    --bg-medium: #e5e7eb;   /* bg-gray-200 */
+    --border-color: #d1d5db;/* border-gray-300 */
+    --text-primary: #1f2937;/* text-gray-800 */
+    --text-secondary: #4b5563;/* text-gray-600 */
+    --accent-color: #0ea5e9; /* sky-500 */
+    --button-primary-bg: #0284c7; /* sky-600 */
+    --button-primary-hover: #0369a1; /* sky-700 */
+}
+
 body {
     background-color: var(--bg-dark);
     color: var(--text-primary);
@@ -41,6 +53,17 @@ body {
     display: flex;
     flex-direction: column;
     flex-grow: 1;
+}
+
+.header-bar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.5rem;
+}
+
+.theme-toggle {
+    margin-left: 1rem;
 }
 
 /* Tipografia */


### PR DESCRIPTION
## Summary
- add a button in the header to toggle theme
- store the selected theme in localStorage
- switch CSS variables when the theme changes

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68554dd49d9c833082f5d1b467804d87