### PR TITLE
Translate comments

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -6,20 +6,17 @@ use serde::{Deserialize, Serialize};
 use tera::Tera;
 use std::{env, path::PathBuf};
 
-// Estrutura para receber o JSON do frontend
 #[derive(Deserialize)]
 struct PathRequest {
     path: String,
     ignore_patterns: Vec<String>,
 }
 
-// Estrutura para enviar a resposta em JSON
 #[derive(Serialize)]
 struct PathResponse {
     content: String,
 }
 
-// Handler para a rota principal, renderiza o index.html
 async fn index(tera: web::Data<Tera>) -> impl Responder {
     let context = tera::Context::new();
     match tera.render("index.html", &context) {
@@ -31,22 +28,19 @@ async fn index(tera: web::Data<Tera>) -> impl Responder {
     }
 }
 
-// Handler para a rota da API que processa o caminho
 async fn process_path(req: web::Json<PathRequest>) -> Result<HttpResponse, error::Error> {
-    // 1. Lê a variável de ambiente para saber o diretório base.
-    // 2. Se a variável não for definida, usa "." (diretório atual) como padrão.
-    //    Isso faz com que `cargo run` funcione de forma intuitiva.
+    // 1. Read the environment variable that defines the base directory.
+    // 2. If it's not set, use "." so that `cargo run` behaves intuitively.
     let base_dir = env::var("DATA_DIR_BASE").unwrap_or_else(|_| ".".to_string());
 
-    // Constrói o caminho completo a partir da base configurada e do input do usuário.
     let mut path_to_process = PathBuf::new();
     path_to_process.push(base_dir);
     path_to_process.push(&req.path);
-    
-    // Resolve caminhos como ".." para evitar sair do diretório base (Path Traversal)
-    // NOTA: Esta é uma medida de segurança básica. Bibliotecas como `path-clean` podem oferecer mais robustez.
+
+    // Resolve elements like ".." to avoid leaving the base directory (basic path traversal mitigation).
+    // Libraries such as `path-clean` provide more robust handling.
     let Ok(canonical_path) = path_to_process.canonicalize() else {
-        let user_error = format!("Erro: O caminho '{}' não existe ou é inválido.", req.path);
+        let user_error = format!("Error: path '{}' does not exist or is invalid.", req.path);
         return Err(error::ErrorBadRequest(user_error));
     };
     
@@ -58,8 +52,11 @@ async fn process_path(req: web::Json<PathRequest>) -> Result<HttpResponse, error
         Ok(content) => Ok(HttpResponse::Ok().json(PathResponse { content })),
         Err(e) => {
             eprintln!("Error processing path: {}", e);
-            let user_error = format!("Erro ao processar o caminho '{}': {}. Verifique se o caminho existe e se o container tem permissão de leitura.", req.path, e);
-            // Usamos um erro de cliente (400) pois o problema é o input do usuário.
+            let user_error = format!(
+                "Failed to process path '{}': {}. Check that it exists and that the container can read it.",
+                req.path, e
+            );
+            // Use a client error (400) because the issue lies with user input.
             Err(error::ErrorBadRequest(user_error))
         }
     }
@@ -70,16 +67,15 @@ async fn main() -> std::io::Result<()> {
     println!("🚀 Servidor iniciado em http://localhost:3000");
 
     HttpServer::new(|| {
-        // Inicializa o motor de templates Tera
         let tera = Tera::new("src/templates/**/*").expect("Failed to parse templates.");
 
         App::new()
             .app_data(web::Data::new(tera))
             .route("/", web::get().to(index))
             .route("/api/process", web::post().to(process_path))
-            .service(Files::new("/static", "static/")) // Serve arquivos estáticos
+            .service(Files::new("/static", "static/"))
     })
-    .bind("0.0.0.0:3000")? // Bind em 0.0.0.0 é essencial para o Docker
+    .bind("0.0.0.0:3000")? // Binding to 0.0.0.0 is required for Docker
     .run()
     .await
 }


### PR DESCRIPTION
## Summary
- translate and simplify comments in the Rust source files
- keep only comments that explain non-obvious behavior

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685555af0a908330afa6e3692b6ba974