### PR TITLE
Add precise token counting via tiktoken-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,6 +263,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -288,6 +294,21 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
@@ -332,6 +353,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
 dependencies = [
  "memchr",
+ "regex-automata",
  "serde",
 ]
 
@@ -576,6 +598,17 @@ checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1404,6 +1437,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1661,6 +1700,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiktoken-rs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25563eeba904d770acf527e8b370fe9a5547bacd20ff84a0b6c3bc41288e5625"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bstr",
+ "fancy-regex",
+ "lazy_static",
+ "regex",
+ "rustc-hash",
+]
+
+[[package]]
 name = "time"
 version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1712,6 +1766,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tera",
+ "tiktoken-rs",
  "walkdir",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ walkdir = "2.5.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.120"
 glob = "0.3.1"
+tiktoken-rs = "0.7.0"
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The entire application runs as a single, self-contained binary and is fully cont
 -   **Recursive Directory Analysis**: Provide a path to a local project, and the tool recursively scans its structure.
 -   **File Tree and Content View**: Displays a clean file tree followed by the full content of each file, complete with line numbers for easy reference.
 -   **Dynamic Ignore Patterns**: Use glob patterns (e.g., `node_modules`, `*.log`, `target/**`) to exclude specific files and directories from the analysis in real-time.
--   **Token Estimation**: Get a rough estimate of the token count for the entire processed text, helping to gauge context size for LLMs.
+-   **Token Counting**: Uses the `tiktoken-rs` implementation of OpenAI's `cl100k_base` tokenizer to precisely measure tokens for the concatenated output.
 -   **Fully Dockerized**: Includes separate, optimized Dockerfiles for development (with hot-reloading) and production (with a minimal final image).
 -   **Zero Frontend Dependencies**: The UI is built with pure, dependency-free HTML, CSS, and vanilla JavaScript.
 
@@ -23,6 +23,7 @@ The entire application runs as a single, self-contained binary and is fully cont
     -   [WalkDir](https://crates.io/crates/walkdir): For recursive directory traversal.
     -   [Glob](https://crates.io/crates/glob): For matching ignore patterns.
     -   [Tera](https://tera.netlify.app/): Templating engine for HTML rendering.
+    -   [tiktoken-rs](https://crates.io/crates/tiktoken-rs): Accurate tokenization for OpenAI models.
 -   **Frontend**:
     -   HTML5
     -   Pure CSS3

--- a/src/file_tree.rs
+++ b/src/file_tree.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::path::Path;
 use walkdir::{DirEntry, WalkDir};
 use glob::Pattern;
-use tiktoken_rs::cl100k_base_singleton;
+use tiktoken_rs::o200k_base_singleton;
 
 fn is_ignored(entry: &DirEntry, root_path: &Path, ignore_patterns: &[Pattern]) -> bool {
     if let Ok(relative_path) = entry.path().strip_prefix(root_path) {
@@ -107,7 +107,7 @@ pub fn generate_tree_and_content(
 
 /// Conta tokens usando o modelo cl100k_base do tiktoken-rs.
 pub fn count_tokens(text: &str) -> usize {
-    let bpe = cl100k_base_singleton();
+    let bpe = o200k_base_singleton();
     bpe.encode_with_special_tokens(text).len()
 }
 

--- a/src/file_tree.rs
+++ b/src/file_tree.rs
@@ -1,7 +1,8 @@
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use walkdir::{DirEntry, WalkDir};
 use glob::Pattern;
+use tiktoken_rs::cl100k_base_singleton;
 
 /// Função auxiliar para verificar se uma entrada deve ser ignorada
 fn is_ignored(entry: &DirEntry, root_path: &Path, ignore_patterns: &[Pattern]) -> bool {
@@ -117,6 +118,12 @@ pub fn generate_tree_and_content(
     }
 
     Ok(final_output)
+}
+
+/// Conta tokens usando o modelo cl100k_base do tiktoken-rs.
+pub fn count_tokens(text: &str) -> usize {
+    let bpe = cl100k_base_singleton();
+    bpe.encode_with_special_tokens(text).len()
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ struct PathRequest {
 #[derive(Serialize)]
 struct PathResponse {
     content: String,
+    token_count: usize,
 }
 
 // Handler para a rota principal, renderiza o index.html
@@ -55,7 +56,10 @@ async fn process_path(req: web::Json<PathRequest>) -> Result<HttpResponse, error
     println!("Ignorando padrões: {:?}", req.ignore_patterns);
 
     match file_tree::generate_tree_and_content(&canonical_path, &req.ignore_patterns) {
-        Ok(content) => Ok(HttpResponse::Ok().json(PathResponse { content })),
+        Ok(content) => {
+            let token_count = file_tree::count_tokens(&content);
+            Ok(HttpResponse::Ok().json(PathResponse { content, token_count }))
+        },
         Err(e) => {
             eprintln!("Error processing path: {}", e);
             let user_error = format!("Erro ao processar o caminho '{}': {}. Verifique se o caminho existe e se o container tem permissão de leitura.", req.path, e);

--- a/static/app.js
+++ b/static/app.js
@@ -99,6 +99,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
             const data = await response.json();
             output.textContent = data.content;
+            tokenCountSpan.textContent = data.token_count.toLocaleString('pt-BR');
             controls.classList.remove('hidden');
 
         } catch (error) {
@@ -108,29 +109,6 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     });
 
-    // Função para estimar tokens e botão de copiar (inalterados)
-    const estimateTokens = (text) => {
-        if (!text) return 0;
-
-        // Regra 1: Contagem baseada em caracteres (uma regra de ouro comum é ~4 caracteres por token)
-        const charBasedCount = text.length / 4;
-
-        // Regra 2: Contagem baseada em "palavras" e símbolos
-        // Separa por espaços E por caracteres comuns em código que viram tokens
-        const wordLikeTokens = text.split(/[\s\n\r(){}\[\];.,_=\->:]+/).filter(Boolean);
-        const wordBasedCount = wordLikeTokens.length;
-
-        // Média ponderada: Damos mais peso à contagem de palavras/símbolos, 
-        // mas a contagem de caracteres ajuda a corrigir.
-        const estimatedCount = Math.ceil((wordBasedCount * 0.75) + (charBasedCount * 0.25));
-        
-        return estimatedCount;
-    };
-
-    const observer = new MutationObserver(() => {
-        tokenCountSpan.textContent = estimateTokens(output.textContent).toLocaleString('pt-BR');
-    });
-    observer.observe(output, { childList: true, characterData: true, subtree: true });
 
     copyButton.addEventListener('click', () => {
         navigator.clipboard.writeText(output.textContent).then(() => {


### PR DESCRIPTION
## Summary
- integrate `tiktoken-rs` for computing token counts
- expose the token count in API responses
- show the backend-calculated token count in the UI
- document new functionality and dependency

## Testing
- `cargo test`
- `cargo build`


------
https://chatgpt.com/codex/tasks/task_e_68555570225c833080d0fe1c39992ee4