### PR TITLE
Add progress streaming and progress bar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -655,6 +655,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -673,9 +684,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-task",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -1761,12 +1774,16 @@ version = "0.1.0"
 dependencies = [
  "actix-files",
  "actix-web",
+ "bytes",
+ "futures-util",
  "glob",
  "serde",
  "serde_json",
  "tempfile",
  "tera",
  "tiktoken-rs",
+ "tokio",
+ "tokio-stream",
  "walkdir",
 ]
 
@@ -1784,7 +1801,30 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,10 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.120"
 glob = "0.3.1"
 tiktoken-rs = "0.7.0"
+tokio-stream = "0.1"
+tokio = { version = "1", features = ["rt", "macros"] }
+bytes = "1"
+futures-util = "0.3"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,11 @@ mod file_tree;
 
 use actix_files::Files;
 use actix_web::{web, App, HttpServer, Responder, HttpResponse, error};
+use bytes::Bytes;
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::UnboundedReceiverStream;
+use futures_util::StreamExt;
+use serde_json::json;
 use serde::{Deserialize, Serialize};
 use tera::Tera;
 use std::{env, path::PathBuf};
@@ -66,6 +71,54 @@ async fn process_path(req: web::Json<PathRequest>) -> Result<HttpResponse, error
     }
 }
 
+async fn process_path_stream(req: web::Json<PathRequest>) -> Result<HttpResponse, error::Error> {
+    let base_dir = env::var("DATA_DIR_BASE").unwrap_or_else(|_| ".".to_string());
+
+    let mut path_to_process = PathBuf::new();
+    path_to_process.push(base_dir);
+    path_to_process.push(&req.path);
+
+    let Ok(canonical_path) = path_to_process.canonicalize() else {
+        let user_error = format!("Error: path '{}' does not exist or is invalid.", req.path);
+        return Err(error::ErrorBadRequest(user_error));
+    };
+
+    let (out_tx, out_rx) = mpsc::unbounded_channel::<Bytes>();
+    let (progress_tx, mut progress_rx) = mpsc::unbounded_channel::<file_tree::Progress>();
+
+    // Forward progress updates as JSON lines
+    let out_tx_clone = out_tx.clone();
+    tokio::spawn(async move {
+        while let Some(p) = progress_rx.recv().await {
+            let pct = if p.total == 0 { 100.0 } else { (p.processed as f32 / p.total as f32) * 100.0 };
+            let msg = json!({"progress": pct});
+            let _ = out_tx_clone.send(Bytes::from(format!("{}\n", msg)));
+        }
+    });
+
+    let out_tx_clone = out_tx.clone();
+    let ignore = req.ignore_patterns.clone();
+    tokio::task::spawn_blocking(move || {
+        match file_tree::generate_tree_and_content_with_progress(&canonical_path, &ignore, &progress_tx) {
+            Ok(content) => {
+                let token_count = file_tree::count_tokens(&content);
+                let msg = json!({"done": true, "content": content, "token_count": token_count});
+                let _ = out_tx_clone.send(Bytes::from(format!("{}\n", msg)));
+            }
+            Err(e) => {
+                let msg = json!({"error": e.to_string()});
+                let _ = out_tx_clone.send(Bytes::from(format!("{}\n", msg)));
+            }
+        }
+    });
+
+    let stream = UnboundedReceiverStream::new(out_rx).map(Ok::<Bytes, error::Error>);
+
+    Ok(HttpResponse::Ok()
+        .insert_header(("Content-Type", "application/json"))
+        .streaming(stream))
+}
+
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
     println!("🚀 Servidor iniciado em http://localhost:3000");
@@ -77,6 +130,7 @@ async fn main() -> std::io::Result<()> {
             .app_data(web::Data::new(tera))
             .route("/", web::get().to(index))
             .route("/api/process", web::post().to(process_path))
+            .route("/api/process_stream", web::post().to(process_path_stream))
             .service(Files::new("/static", "static/"))
     })
     .bind("0.0.0.0:3000")? // Binding to 0.0.0.0 is required for Docker

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -48,6 +48,9 @@
         <div class="output-container">
             <pre id="output" class="output-pre"></pre>
             <div id="loading" class="loading-indicator hidden">Analisando arquivos...</div>
+            <div id="progress-container" class="progress hidden">
+                <div id="progress-bar" class="progress-bar"></div>
+            </div>
         </div>
     </main>
 

--- a/static/style.css
+++ b/static/style.css
@@ -177,6 +177,22 @@ body {
     padding: 2rem;
 }
 
+.progress {
+    width: 100%;
+    height: 0.5rem;
+    background-color: var(--border-color);
+    border-radius: 6px;
+    overflow: hidden;
+    margin-top: 0.5rem;
+}
+
+.progress-bar {
+    height: 100%;
+    width: 0%;
+    background-color: var(--accent-color);
+    transition: width 0.2s ease;
+}
+
 /* Responsividade para o formulário */
 @media (max-width: 640px) {
     .path-form {


### PR DESCRIPTION
## Summary
- stream progress from backend using new `/api/process_stream` endpoint
- add optional progress updates during file generation
- implement frontend progress bar and streaming fetch

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68555cde26bc83308088a4a2cc44d554