### PR TITLE
Add cancel analysis feature

### DIFF
--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -47,7 +47,10 @@
         
         <div class="output-container">
             <pre id="output" class="output-pre"></pre>
-            <div id="loading" class="loading-indicator hidden">Analisando arquivos...</div>
+            <div id="loading" class="loading-indicator hidden">
+                Analisando arquivos...
+                <button id="cancel-button" class="button" type="button">Cancelar</button>
+            </div>
         </div>
     </main>
 


### PR DESCRIPTION
## Summary
- add a cancel button to the analysis output section
- wire up AbortController logic in app.js
- handle cancel events and show user feedback

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68555ccc7494833082ad8558a5750641