### PR TITLE
Add colorized logging with level control

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,6 +430,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "colored"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1775,6 +1784,7 @@ dependencies = [
  "actix-files",
  "actix-web",
  "bytes",
+ "colored",
  "futures-util",
  "glob",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ tokio-stream = "0.1"
 tokio = { version = "1", features = ["rt", "macros"] }
 bytes = "1"
 futures-util = "0.3"
+colored = "3.0"
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -88,7 +88,17 @@ This is ideal for quick tests or if you prefer not to use Docker.
     cargo run
     ```
 3.  The application will be available at `http://localhost:3000`.
+
 4.  Since the app is running directly on your host, you can provide any absolute path (e.g., `/home/user/my-app`) or a path relative to the `tokenizator-plus` directory in the web UI.
+
+### Environment Variables
+
+- `DATA_DIR_BASE`: Base directory that user-supplied paths are resolved against. When using the Docker image, this is typically `/data`.
+- `LOG_LEVEL`: Controls verbosity of server logs. Accepted values are `error`, `warn`, `info` (default), and `debug`.
+  Example:
+  ```bash
+  LOG_LEVEL=debug cargo run
+  ```
 
 ## ⚙️ How to Use the Interface
 

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,0 +1,66 @@
+use colored::*;
+use std::env;
+
+#[derive(PartialEq, PartialOrd)]
+pub enum LogLevel {
+    Error = 1,
+    Warn = 2,
+    Info = 3,
+    Debug = 4,
+}
+
+fn current_level() -> LogLevel {
+    match env::var("LOG_LEVEL")
+        .unwrap_or_else(|_| "info".to_string())
+        .to_lowercase()
+        .as_str()
+    {
+        "error" => LogLevel::Error,
+        "warn" => LogLevel::Warn,
+        "debug" => LogLevel::Debug,
+        "info" => LogLevel::Info,
+        _ => LogLevel::Info,
+    }
+}
+
+pub fn log(level: LogLevel, msg: &str) {
+    let env_level = current_level();
+    if level <= env_level {
+        let level_str = match level {
+            LogLevel::Error => "ERROR".red().bold(),
+            LogLevel::Warn => "WARN".yellow().bold(),
+            LogLevel::Info => "INFO".green().bold(),
+            LogLevel::Debug => "DEBUG".blue().bold(),
+        };
+        println!("[{}] {}", level_str, msg);
+    }
+}
+
+#[macro_export]
+macro_rules! log_error {
+    ($($arg:tt)*) => {
+        $crate::logger::log($crate::logger::LogLevel::Error, &format!($($arg)*));
+    };
+}
+
+#[macro_export]
+macro_rules! log_warn {
+    ($($arg:tt)*) => {
+        $crate::logger::log($crate::logger::LogLevel::Warn, &format!($($arg)*));
+    };
+}
+
+#[macro_export]
+macro_rules! log_info {
+    ($($arg:tt)*) => {
+        $crate::logger::log($crate::logger::LogLevel::Info, &format!($($arg)*));
+    };
+}
+
+#[macro_export]
+macro_rules! log_debug {
+    ($($arg:tt)*) => {
+        $crate::logger::log($crate::logger::LogLevel::Debug, &format!($($arg)*));
+    };
+}
+


### PR DESCRIPTION
## Summary
- implement a simple colored logger controlled by `LOG_LEVEL`
- replace `println!`/`eprintln!` calls with log macros
- add debug logs for ignored files and file reading in `file_tree`
- document `LOG_LEVEL` in README

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_685c92ade4748330afa7b044b565a16a