### PR TITLE
Add optional Tree-sitter AST summarization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1784,6 +1784,10 @@ dependencies = [
  "tiktoken-rs",
  "tokio",
  "tokio-stream",
+ "tree-sitter",
+ "tree-sitter-javascript",
+ "tree-sitter-python",
+ "tree-sitter-rust",
  "walkdir",
 ]
 
@@ -1870,6 +1874,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0203df02a3b6dd63575cc1d6e609edc2181c9a11867a271b25cfd2abff3ec5ca"
+dependencies = [
+ "cc",
+ "regex",
+ "regex-syntax",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-javascript"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf40bf599e0416c16c125c3cec10ee5ddc7d1bb8b0c60fa5c4de249ad34dc1b1"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4013970217383f67b18aef68f6fb2e8d409bc5755227092d32efb0422ba24b8"
+
+[[package]]
+name = "tree-sitter-python"
+version = "0.23.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d065aaa27f3aaceaf60c1f0e0ac09e1cb9eb8ed28e7bcdaa52129cffc7f4b04"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-rust"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca8ccb3e3a3495c8a943f6c3fd24c3804c471fd7f4f16087623c7fa4c0068e8a"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,10 @@ tokio-stream = "0.1"
 tokio = { version = "1", features = ["rt", "macros"] }
 bytes = "1"
 futures-util = "0.3"
+tree-sitter = "0.23"
+tree-sitter-rust = "0.23"
+tree-sitter-javascript = "0.23"
+tree-sitter-python = "0.23"
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The entire application runs as a single, self-contained binary and is fully cont
 -   **File Tree and Content View**: Displays a clean file tree followed by the full content of each file, complete with line numbers for easy reference.
 -   **Dynamic Ignore Patterns**: Use glob patterns (e.g., `node_modules`, `*.log`, `target/**`) to exclude specific files and directories from the analysis in real-time.
 -   **Token Counting**: Uses the `tiktoken-rs` implementation of OpenAI's `cl100k_base` tokenizer to precisely measure tokens for the concatenated output.
+-   **Optional AST Summaries**: Toggle a Tree-sitter based summary that lists functions and types to drastically reduce token usage when needed.
 -   **Fully Dockerized**: Includes separate, optimized Dockerfiles for development (with hot-reloading) and production (with a minimal final image).
 -   **Zero Frontend Dependencies**: The UI is built with pure, dependency-free HTML, CSS, and vanilla JavaScript.
 

--- a/src/ast_summary.rs
+++ b/src/ast_summary.rs
@@ -1,0 +1,67 @@
+use std::path::Path;
+use tree_sitter::{Language, Parser, TreeCursor};
+use tree_sitter_rust::LANGUAGE as RUST;
+use tree_sitter_javascript::LANGUAGE as JAVASCRIPT;
+use tree_sitter_python::LANGUAGE as PYTHON;
+
+fn parser_for_extension(ext: &str) -> Option<Language> {
+    match ext {
+        "rs" => Some(RUST.into()),
+        "js" | "jsx" | "ts" | "tsx" => Some(JAVASCRIPT.into()),
+        "py" => Some(PYTHON.into()),
+        _ => None,
+    }
+}
+
+fn summarize_nodes(cursor: &mut TreeCursor, source: &str, summary: &mut String) {
+    let node = cursor.node();
+    match node.kind() {
+        "function_item" | "function_declaration" | "method_definition" | "function_definition" => {
+            if let Some(name) = node.child_by_field_name("name") {
+                if let Ok(txt) = name.utf8_text(source.as_bytes()) {
+                    summary.push_str(&format!("fn {}\n", txt));
+                }
+            }
+        }
+        "struct_item" | "class_declaration" | "class_definition" => {
+            if let Some(name) = node.child_by_field_name("name") {
+                if let Ok(txt) = name.utf8_text(source.as_bytes()) {
+                    summary.push_str(&format!("class {}\n", txt));
+                }
+            }
+        }
+        "enum_item" => {
+            if let Some(name) = node.child_by_field_name("name") {
+                if let Ok(txt) = name.utf8_text(source.as_bytes()) {
+                    summary.push_str(&format!("enum {}\n", txt));
+                }
+            }
+        }
+        _ => {}
+    }
+    if cursor.goto_first_child() {
+        loop {
+            summarize_nodes(cursor, source, summary);
+            if !cursor.goto_next_sibling() {
+                break;
+            }
+        }
+        cursor.goto_parent();
+    }
+}
+
+pub fn summarize(path: &Path, content: &str) -> Option<String> {
+    let ext = path.extension()?.to_str()?;
+    let language = parser_for_extension(ext)?;
+    let mut parser = Parser::new();
+    parser.set_language(&language).ok()?;
+    let tree = parser.parse(content, None)?;
+    let mut cursor = tree.root_node().walk();
+    let mut summary = String::new();
+    summarize_nodes(&mut cursor, content, &mut summary);
+    if summary.is_empty() {
+        None
+    } else {
+        Some(summary)
+    }
+}

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -11,6 +11,9 @@
         <div class="header-bar">
             <h1 class="title">Tokenizator Plus</h1>
             <button id="theme-toggle" class="button theme-toggle">Tema Claro</button>
+            <label class="summary-toggle">
+                <input type="checkbox" id="summary-toggle"> Resumo AST
+            </label>
         </div>
         <p class="subtitle">Cole o caminho de uma pasta e adicione padrões para ignorar arquivos ou diretórios.</p>
 

--- a/static/app.js
+++ b/static/app.js
@@ -10,6 +10,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const progressContainer = document.getElementById('progress-container');
     const progressBar = document.getElementById('progress-bar');
     const themeToggle = document.getElementById('theme-toggle');
+    const summaryToggle = document.getElementById('summary-toggle');
     
     // Novos elementos para a feature de ignorar
     const ignoreForm = document.getElementById('ignore-form');
@@ -104,7 +105,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
                     path: path,
-                    ignore_patterns: ignorePatterns // Envia o array de padrões
+                    ignore_patterns: ignorePatterns, // Envia o array de padrões
+                    ast_summary: summaryToggle.checked
                 }),
             });
             if (!response.ok) {

--- a/static/style.css
+++ b/static/style.css
@@ -66,6 +66,14 @@ body {
     margin-left: 1rem;
 }
 
+.summary-toggle {
+    margin-left: 1rem;
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    font-size: 0.875rem;
+}
+
 /* Tipografia */
 .title {
     font-size: 2rem;


### PR DESCRIPTION
## Summary
- add tree-sitter language crates and AST summarizer module
- support AST summarization in file tree generation and API
- expose `ast_summary` toggle in UI
- style toggle and document feature

## Testing
- `cargo test`
- `cargo build`


------
https://chatgpt.com/codex/tasks/task_e_685ca3a9845c8330ba3b149ab3e5ba0e